### PR TITLE
Fix for a missing room object in hub.lua:ShouldRemoveTransitionDoor()

### DIFF
--- a/scripts/hubroom2/hub.lua
+++ b/scripts/hubroom2/hub.lua
@@ -220,7 +220,7 @@ hub2.RepDoors = {
 local CheckedOutDoorSlots = {}
 
 local function ShouldRemoveTransitionDoor()
-	if room:GetType() == RoomType.ROOM_BOSS and StageAPI.InOverriddenStage() then
+	if game:GetRoom():GetType() == RoomType.ROOM_BOSS and StageAPI.InOverriddenStage() then
 		local currentStage = StageAPI.GetCurrentStage()
 		return currentStage and not hub2.CustomStagesContainingHub2[currentStage.Name]
 	end


### PR DESCRIPTION
this one caused plenty of errors in the debug console for no good reason